### PR TITLE
refactor: Move 'mark as watched' feature to videoAPI

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -82,12 +82,6 @@ export const channelAPI = {
       return data;
     });
   },
-
-  markAsWatched: async (videoId: string): Promise<void> => {
-    return makeRequest(async () => {
-      await api.post(`/videos/${videoId}/watch`);
-    });
-  },
 };
 
 // Configuration APIs
@@ -138,6 +132,12 @@ export const videoAPI = {
       const url = refresh ? '/videos?refresh=true' : '/videos';
       const { data } = await api.get<VideosAPIResponse>(url);
       return data;
+    });
+  },
+
+  markAsWatched: async (videoId: string): Promise<void> => {
+    return makeRequest(async () => {
+      await api.post(`/videos/${videoId}/watch`);
     });
   },
 };


### PR DESCRIPTION
- Removed the 'markAsWatched' method from channelAPI and added it to videoAPI for better organization and clarity.
- This change aligns with the API structure, ensuring that video-related functionalities are encapsulated within the videoAPI module.